### PR TITLE
chore: cleanup and refactor of apollo queries, mutations, and cache

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,10 +1,5 @@
 import React from 'react'
-import {
-  Redirect,
-  Route,
-  Switch,
-  BrowserRouter as Router
-} from 'react-router-dom'
+import { Redirect, Route, Switch } from 'react-router-dom'
 import decode from 'jwt-decode'
 
 import MainPage from './MainPage'
@@ -49,22 +44,18 @@ const PrivateRoute = ({ component: Component, ...rest }) => {
   )
 }
 
-const App = () => {
-  return (
-    <Router>
-      <>
-        <Route
-          path="/"
-          render={props => <Header {...props} isAuthed={checkAuth()} />}
-        />
-        <Switch>
-          <Route exact path="/signup" component={SignUp} />
-          <Route exact path="/signin" component={SignIn} />
-          <PrivateRoute exact path="/books" component={MainPage} />
-        </Switch>
-      </>
-    </Router>
-  )
-}
+const App = () => (
+  <>
+    <Route
+      path="/"
+      render={props => <Header {...props} isAuthed={checkAuth()} />}
+    />
+    <Switch>
+      <Route exact path="/signup" component={SignUp} />
+      <Route exact path="/signin" component={SignIn} />
+      <PrivateRoute exact path="/books" component={MainPage} />
+    </Switch>
+  </>
+)
 
 export default App

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,24 +1,20 @@
 import React from 'react'
-import { useMutation } from 'react-apollo-hooks'
+import { compose, withApollo } from 'react-apollo'
+import { withRouter } from 'react-router-dom'
 
-import {
-  Anchor,
-  AnchorWrapper,
-  HeaderWrapper,
-  Nav,
-  UPDATELOGINSTATUS,
-} from '../constants'
+import { Anchor, AnchorWrapper, HeaderWrapper, Nav, Button } from '../constants'
 import NavLink from './Link'
 
-const renderNavButton = (isAuthed, updateLoginStatus) => {
+const renderNavButton = (history, client, isAuthed) => {
   const handleClick = () => {
     localStorage.removeItem('token')
     localStorage.removeItem('refreshToken')
-    updateLoginStatus({ variables: { loggedIn: false } })
+    client.cache.reset()
+    history.push('/signin')
   }
 
   if (isAuthed) {
-    return <NavLink to="/" onClick={handleClick}>SignOut</NavLink>
+    return <Button onClick={handleClick}>SignOut</Button>
   } else {
     return (
       <div
@@ -35,18 +31,20 @@ const renderNavButton = (isAuthed, updateLoginStatus) => {
   }
 }
 
-const Header = ({ isAuthed }) => {
-  const updateLoginStatus = useMutation(UPDATELOGINSTATUS)
+const Header = ({ history, client, isAuthed }) => {
   return (
     <HeaderWrapper>
       <Nav>
         <AnchorWrapper>
           <Anchor>BookCMS</Anchor>
-          {renderNavButton(isAuthed, updateLoginStatus)}
+          {renderNavButton(history, client, isAuthed)}
         </AnchorWrapper>
       </Nav>
     </HeaderWrapper>
   )
 }
 
-export default Header
+export default compose(
+  withApollo,
+  withRouter
+)(Header)

--- a/src/components/MainPage.js
+++ b/src/components/MainPage.js
@@ -30,9 +30,11 @@ const MainPage = () => (
         <FilterCategories />
       </Suspense>
       <DashBoard buttonText="ADD BOOK">
-        <BooksForm  formType="SAVE" />
+        <BooksForm formType="SAVE" />
       </DashBoard>
-      <BooksList />
+      <Suspense fallback={<span>Loading books</span>}>
+        <BooksList />
+      </Suspense>
     </MainContent>
   </MainContainer>
 )

--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { useMutation } from 'react-apollo-hooks'
-import { compose, graphql } from 'react-apollo'
+import { compose, withApollo } from 'react-apollo'
+import { withRouter } from 'react-router-dom'
 
 import {
   Input,
@@ -9,11 +10,10 @@ import {
   RegistrationForm,
   SmallButton,
   Label,
-  UPDATELOGINSTATUS,
   SIGNIN
 } from '../constants'
 
-const SignIn = ({ history, updateLoginStatus }) => {
+const SignIn = ({ client, history }) => {
   const [signInDetail, setSignInDetail] = useState({ login: '', password: '' })
 
   const handleChange = key => e => {
@@ -25,9 +25,7 @@ const SignIn = ({ history, updateLoginStatus }) => {
     if (token && refreshToken) {
       localStorage.setItem('token', token)
       localStorage.setItem('refreshToken', refreshToken)
-      updateLoginStatus({
-        variables: { loggedIn: true }
-      })
+      client.cache.reset()
       history.push('/books')
     }
   }
@@ -77,5 +75,6 @@ const SignIn = ({ history, updateLoginStatus }) => {
 }
 
 export default compose(
-  graphql(UPDATELOGINSTATUS, { name: 'updateLoginStatus' })
+  withApollo,
+  withRouter
 )(SignIn)

--- a/src/components/SignUp.js
+++ b/src/components/SignUp.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react'
 import { compose, graphql } from 'react-apollo'
 import { useMutation } from 'react-apollo-hooks'
-import history from '../history'
 
 import {
   RegistrationForm,
@@ -14,7 +13,7 @@ import {
   UPDATELOGINSTATUS
 } from '../constants'
 
-const SignUp = ({ updateLoginStatus }) => {
+const SignUp = ({ history, updateLoginStatus }) => {
   const [signUpDetail, setSignUpDetail] = useState({
     username: '',
     email: '',

--- a/src/components/SignUp.js
+++ b/src/components/SignUp.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
-import { compose, graphql } from 'react-apollo'
+import { withApollo, compose } from 'react-apollo'
 import { useMutation } from 'react-apollo-hooks'
+import { withRouter } from 'react-router-dom'
 
 import {
   RegistrationForm,
@@ -10,10 +11,9 @@ import {
   LabelContainer,
   SmallButton,
   SIGNUP,
-  UPDATELOGINSTATUS
 } from '../constants'
 
-const SignUp = ({ history, updateLoginStatus }) => {
+const SignUp = ({ client, history }) => {
   const [signUpDetail, setSignUpDetail] = useState({
     username: '',
     email: '',
@@ -29,9 +29,7 @@ const SignUp = ({ history, updateLoginStatus }) => {
     if (token && refreshToken) {
       localStorage.setItem('token', token)
       localStorage.setItem('refreshToken', refreshToken)
-      updateLoginStatus({
-        variables: { loggedIn: true }
-      })
+      client.cache.reset()
       history.push('/books')
     }
   }
@@ -91,5 +89,6 @@ const SignUp = ({ history, updateLoginStatus }) => {
 }
 
 export default compose(
-  graphql(UPDATELOGINSTATUS, { name: 'updateLoginStatus' })
+  withRouter,
+  withApollo
 )(SignUp)

--- a/src/constants/graphql.js
+++ b/src/constants/graphql.js
@@ -53,7 +53,6 @@ const MYBOOKS = gql`
   query GetMyBooks($input: booksInput!) {
     myBooks(input: $input) {
       edges {
-        __typename
         id
         title
         author
@@ -63,7 +62,6 @@ const MYBOOKS = gql`
         currentChapter
         chapters
       }
-
       pageInfo {
         endCursor
         hasNextPage

--- a/src/containers/BooksForm.js
+++ b/src/containers/BooksForm.js
@@ -31,7 +31,7 @@ const BooksForm = ({
     author: book ? book.author : '',
     category: book ? book.category : 'Novel',
     pages: book ? book.pages : 125,
-    chapters: book? book.chapters : 13
+    chapters: book ? book.chapters : 13
   })
 
   const handleChange = key => e => {
@@ -40,13 +40,13 @@ const BooksForm = ({
   }
 
   const addBook = useMutation(CREATEBOOK, {
-    update: (cache, { data: { createBook } }) => {
-      createBook.currentPage = 0
+    update: async (cache, { data: { createBook } }) => {
+      createBook.currentPage = 1
       createBook.currentChapter = 1
 
       const {
         myBooks: { edges, pageInfo }
-      } = cache.readQuery({
+      } = await cache.readQuery({
         query: MYBOOKS,
         variables: { input: { limit: 5 } }
       })
@@ -57,11 +57,14 @@ const BooksForm = ({
         data: {
           myBooks: {
             __typename: 'BookConnection',
-            edges: [
-              Object.assign(createBook, { __typename: 'Book' }),
-              ...edges
-            ],
-            pageInfo
+            edges: edges
+              ? [Object.assign(createBook, { __typename: 'Book' }), ...edges]
+              : [Object.assign(createBook, { __typename: 'Book' })],
+            pageInfo: pageInfo || {
+              __typename: 'PageInfo',
+              endCursor: '',
+              hasNextPage: false
+            }
           }
         }
       })
@@ -101,7 +104,7 @@ const BooksForm = ({
             data: { editBook }
           } = await editBookData({ variables })
 
-          setBookDetail(prevState => ({...prevState, ...variables.input}))
+          setBookDetail(prevState => ({ ...prevState, ...variables.input }))
           categoryVal = editBook.category
         }
 

--- a/src/containers/BooksList.js
+++ b/src/containers/BooksList.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Query, compose, graphql } from 'react-apollo'
+import { Query } from 'react-apollo'
+import { useQuery } from 'react-apollo-hooks'
 
 import Book from '../components/Book'
 import { Button, MYBOOKS, GETCATEGORYFILTER } from '../constants'
@@ -36,7 +37,12 @@ const updateQuery = (
   }
 }
 
-const BooksList = ({ category, categories }) => {
+const BooksList = () => {
+  const {
+    data: {
+      filter: { category }
+    }
+  } = useQuery(GETCATEGORYFILTER)
   return (
     <Query query={MYBOOKS} variables={{ input: { limit: 5 } }}>
       {({ loading, data, fetchMore }) => {
@@ -82,12 +88,4 @@ const BooksList = ({ category, categories }) => {
   )
 }
 
-export default compose(
-  graphql(GETCATEGORYFILTER, {
-    props: ({
-      data: {
-        filter: { category }
-      }
-    }) => ({ category })
-  })
-)(BooksList)
+export default BooksList

--- a/src/containers/BooksList.js
+++ b/src/containers/BooksList.js
@@ -48,11 +48,11 @@ const BooksList = ({ category, categories }) => {
           myBooks: { edges: books, pageInfo }
         } = data
 
-        const filteredBooks = filterBooksByCategoryFilter(books, category)
-
-        if (!Boolean(books.length)) {
+        if (!books) {
           return <p>Add a new book below</p>
         }
+
+        const filteredBooks = filterBooksByCategoryFilter(books, category)
 
         return (
           <>

--- a/src/containers/FilterCategories.js
+++ b/src/containers/FilterCategories.js
@@ -36,10 +36,13 @@ const FilterCategories = ({
   categories,
   addToCategories
 }) => {
-  const bookQuery = useQuery(MYBOOKS, { variables: { input: { limit: 10 } } })
+  const {
+    data: {
+      myBooks: { edges: books }
+    }
+  } = useQuery(MYBOOKS, { variables: { input: { limit: 10 } } })
 
-  if (bookQuery.data.myBooks) {
-    const books = bookQuery.data.myBooks.edges
+  if (books && books.length) {
     const bookCategories = extractCategories(books)
     addToCategories({
       variables: { cats: bookCategories }

--- a/src/containers/FilterCategories.js
+++ b/src/containers/FilterCategories.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { useQuery } from 'react-apollo-hooks'
-import { graphql, compose } from 'react-apollo'
+import { useQuery, useMutation } from 'react-apollo-hooks'
 
 import {
   ADDTOFILTERABLECATEGORIES,
@@ -30,17 +29,28 @@ const extractCategories = books => {
   return [...new Set(bookCategories)]
 }
 
-const FilterCategories = ({
-  filter: { category },
-  setCategory,
-  categories,
-  addToCategories
-}) => {
+const FilterCategories = () => {
   const {
     data: {
       myBooks: { edges: books }
     }
   } = useQuery(MYBOOKS, { variables: { input: { limit: 10 } } })
+
+  const {
+    data: {
+      filterable: { categories }
+    }
+  } = useQuery(GETFILTERABLECATEGORIES)
+
+  const {
+    data: {
+      filter: { category }
+    }
+  } = useQuery(GETCATEGORYFILTER)
+
+  const setCategory = useMutation(SETCATEGORYFILTER)
+
+  const addToCategories = useMutation(ADDTOFILTERABLECATEGORIES)
 
   if (books && books.length) {
     const bookCategories = extractCategories(books)
@@ -62,17 +72,4 @@ const FilterCategories = ({
   )
 }
 
-export default compose(
-  graphql(SETCATEGORYFILTER, { name: 'setCategory' }),
-  graphql(ADDTOFILTERABLECATEGORIES, { name: 'addToCategories' }),
-  graphql(GETCATEGORYFILTER, {
-    props: ({ data: { filter } }) => ({ filter })
-  }),
-  graphql(GETFILTERABLECATEGORIES, {
-    props: ({
-      data: {
-        filterable: { categories }
-      }
-    }) => ({ categories })
-  })
-)(FilterCategories)
+export default FilterCategories

--- a/src/index.js
+++ b/src/index.js
@@ -20,9 +20,7 @@ import * as serviceWorker from './serviceWorker'
 import { GETFILTERABLECATEGORIES } from './constants'
 const BOOKCMS_API = 'https://bookcms-api.herokuapp.com'
 
-const cache = new InMemoryCache({
-  dataIdFromObject: e => `${e.__typename}_%${e.id}` || null
-})
+const cache = new InMemoryCache()
 
 const httpLink = new HttpLink({
   uri: BOOKCMS_API
@@ -59,17 +57,6 @@ const stateLink = withClientState({
 
         cache.writeData({ data })
         return null
-      },
-      updateLoginStatus: (_, { loggedIn }, { cache }) => {
-        const data = {
-          auth: {
-            __typename: 'Auth',
-            loggedIn
-          }
-        }
-
-        cache.writeData({ data })
-        return null
       }
     }
   },
@@ -81,10 +68,6 @@ const stateLink = withClientState({
     filterable: {
       __typename: 'Filterable',
       categories: ['All']
-    },
-    auth: {
-      __typename: 'Auth',
-      loggedIn: false
     }
   }
 })
@@ -116,7 +99,9 @@ const authLink = setContext((req, prev) => {
 const afterwareLink = new ApolloLink((operation, forward) =>
   forward(operation).map(response => {
     const context = operation.getContext()
-    const { response: { headers } } = context
+    const {
+      response: { headers }
+    } = context
 
     if (headers) {
       const token = headers.get('token')
@@ -172,13 +157,13 @@ const client = new ApolloClient({
 })
 
 ReactDOM.render(
-  <Router>
-    <ApolloProvider client={client}>
-      <ApolloHooksProvider client={client}>
+  <ApolloProvider client={client}>
+    <ApolloHooksProvider client={client}>
+      <Router>
         <App />
-      </ApolloHooksProvider>
-    </ApolloProvider>
-  </Router>,
+      </Router>
+    </ApolloHooksProvider>
+  </ApolloProvider>,
   document.getElementById('root')
 )
 


### PR DESCRIPTION
Substantial fixes and refactors:
- Forgotten pathway where brand new user has no books. (Was constantly testing test database where user always had minimum of one book)
- reset apollo cache on signin, signup, and signout to prevent auth errors stemming from incorrect user access, cached data from previous user, etc.
- update Mutation on createBook to consider null edges and pageInfo
- refactor composed graphql queries/mutations to useQuery and useMutation hooks
- remove now unnecessary auth flow: 
   - removed auth link state
   - removed auth state update mutation and query